### PR TITLE
Add complete CD pipeline with Tekton and OpenShift

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         app: accounts
     spec:
       containers:
-      - image: us.icr.io/sn-labs-josscui516/accounts:1
+      - image: IMAGE_NAME_HERE
         name: accounts
         resources: {}
 

--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -79,3 +79,22 @@ spec:
       runAfter:
         - tests
         - lint
+
+    - name: deploy
+      workspaces:
+        - name: manifest-dir
+          workspace: pipeline-workspace
+      taskRef:
+        name: openshift-client
+        kind: ClusterTask
+      params:
+      - name: SCRIPT
+        value: |
+          echo "Updating manifest..."
+          sed -i "s|IMAGE_NAME_HERE|$(params.build-image)|g" deploy/deployment.yaml
+          cat deploy/deployment.yaml
+          echo "Deploying to OpenShift..."
+          oc apply -f deploy/
+          oc get pods -l app=accounts
+      runAfter:
+        - build

--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -15,6 +15,7 @@ spec:
     - name: repo-url
     - name: branch
       default: main
+    - name: build-image
   tasks:
     - name: init
       workspaces:
@@ -64,3 +65,17 @@ spec:
         value: "-v --with-spec --spec-color"
       runAfter:
         - clone
+
+    - name: build
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+      taskRef:
+        name: buildah
+        kind: ClusterTask
+      params:
+      - name: IMAGE
+        value: "$(params.build-image)"
+      runAfter:
+        - tests
+        - lint

--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -50,3 +50,17 @@ spec:
         value: ["--count","--max-complexity=10","--max-line-length=127","--statistics"]
       runAfter:
         - clone
+
+    - name: tests
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+      taskRef:
+        name: nose
+      params:
+      - name: database_uri
+        value: "sqlite:///test.db"
+      - name: args
+        value: "-v --with-spec --spec-color"
+      runAfter:
+        - clone

--- a/tekton/tasks.yaml
+++ b/tekton/tasks.yaml
@@ -49,4 +49,38 @@ spec:
           # Delete files and directories starting with .. plus any other character
           rm -rf "${WORKSPACE_SOURCE_PATH}"/..?*
         fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: nose
+spec:
+  description: This task will run nosetests on the provided input.
+  workspaces:
+    - name: source
+  params:
+    - name: args
+      description: Arguments to pass to nose
+      type: string
+      default: "-v"
+    - name: database_uri
+      description: Database connection string
+      type: string
+      default: "sqlite:///test.db"
+  steps:
+    - name: nosetests
+      image: python:3.9-slim
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: DATABASE_URI
+          value: $(params.database_uri)
+      script: |
+        #!/bin/bash
+        set -e
 
+        echo "***** Installing dependencies *****"
+        python -m pip install --upgrade pip wheel
+        pip install -qr requirements.txt
+
+        echo "***** Running nosetests with: $(params.args)"
+        nosetests $(params.args)


### PR DESCRIPTION
This pull request implements a complete CI/CD pipeline using Tekton and OpenShift.

Key features:
- Automated code cloning using git-clone
- Code linting with flake8
- Unit testing using a custom nose task
- Container image build using buildah
- Deployment to OpenShift using openshift-client

The pipeline ensures that linting and testing are performed in parallel, and the build stage is triggered only after successful validation. The deployment stage updates the Kubernetes manifests dynamically and deploys the application to the cluster.

All pipeline stages have been successfully tested and verified.